### PR TITLE
chore: add prettier config license metadata

### DIFF
--- a/apps/prettier-config/package.json
+++ b/apps/prettier-config/package.json
@@ -2,6 +2,7 @@
     "name": "@bravo68web/prettier-config",
     "version": "1.2.6",
     "description": "The official Prettier configuration for bravo68web projects",
+    "license": "MIT",
     "author": "Bravo68web <hi@b68.dev> (https://github.com/bravo68web/)",
     "homepage": "https://github.com/BRAVO68WEB/node-config#readme",
     "repository": {


### PR DESCRIPTION
## Summary

- add `license: MIT` to `@bravo68web/prettier-config`
- align the package manifest with the package's bundled MIT `LICENSE` and the sibling `@bravo68web/eslint-config` / `@bravo68web/tsconfig` manifests

## Verification

- `node -e "const p=require('./apps/prettier-config/package.json'); if (p.license !== 'MIT') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, license:p.license}, null, 2))"`
- `npm pack ./apps/prettier-config --dry-run --ignore-scripts --json`
- `git diff --check`

This is an AI-assisted package metadata cleanup.
